### PR TITLE
gamecore_console: avoid importing timeGetDevCaps

### DIFF
--- a/src/platform/platform_winuser.c
+++ b/src/platform/platform_winuser.c
@@ -343,7 +343,7 @@ CxPlatInitialize(
 
     CxPlatTotalMemory = memInfo.ullTotalPageFile;
 
-#ifdef TIMERR_NOERROR
+#if defined(TIMERR_NOERROR) && !defined(QUIC_GAMECORE_BUILD)
     MMRESULT mmResult;
     if ((mmResult = timeGetDevCaps(&CxPlatTimerCapabilities, sizeof(TIMECAPS))) != TIMERR_NOERROR) {
         QuicTraceEvent(
@@ -366,7 +366,7 @@ CxPlatInitialize(
         goto Error;
     }
 #endif // QUIC_HIGH_RES_TIMERS
-#endif // TIMERR_NOERROR
+#endif // defined(TIMERR_NOERROR) && !defined(QUIC_GAMECORE_BUILD)
 
     Status = CxPlatCryptInitialize();
     if (QUIC_FAILED(Status)) {
@@ -376,19 +376,19 @@ CxPlatInitialize(
 
     CxPlatWorkersInit();
 
-#ifdef TIMERR_NOERROR
+#if defined(TIMERR_NOERROR) && !defined(QUIC_GAMECORE_BUILD)
     QuicTraceLogInfo(
         WindowsUserInitialized2,
         "[ dll] Initialized (AvailMem = %llu bytes, TimerResolution = [%u, %u])",
         CxPlatTotalMemory,
         CxPlatTimerCapabilities.wPeriodMin,
         CxPlatTimerCapabilities.wPeriodMax);
-#else // TIMERR_NOERROR
+#else // defined(TIMERR_NOERROR) && !defined(QUIC_GAMECORE_BUILD)
     QuicTraceLogInfo(
         WindowsUserInitialized,
         "[ dll] Initialized (AvailMem = %llu bytes)",
         CxPlatTotalMemory);
-#endif // TIMERR_NOERROR
+#endif // defined(TIMERR_NOERROR) && !defined(QUIC_GAMECORE_BUILD)
 
 Error:
 


### PR DESCRIPTION
## Description

`timeGetDevCaps` is not available in `WINAPI_FAMILY_GAMES` and importing it in `gamecore_console` builds will crash the process at runtime due to `DLL_NOT_FOUND`. 

See [Windows 10 Software Development Kit (Win10SDK)](https://learn.microsoft.com/en-us/gaming/gdk/_content/gc/getstarted/overviews/sdk-and-tools#windows-10-software-development-kit-win10sdk) for the API family available to Microsoft GDK gaming platform.  

## Testing

Existing tests do not cover the issue fixed by this PR.  
  
The issue should be captured by the linker (and cause build failures) instead of automated tests. We should not link against `OneCore.lib` on `gamecore_console` as it [provides the exports for the subset of Win32 APIs that are common to all Windows 10 devices.](https://learn.microsoft.com/en-us/windows/win32/apiindex/windows-umbrella-libraries). Umbrella libraries are designed to ensure we [restrict \[our\] code to Win32 APIs that are supported in the core OS](https://learn.microsoft.com/en-us/windows/win32/apiindex/windows-apisets#linking-to-umbrella-libraries). For `gamecore_console`, the umbrella library should be [xgameplatform.lib](https://learn.microsoft.com/en-us/gaming/gdk/_content/gc/getstarted/overviews/sdk-and-tools#windows-10-software-development-kit-win10sdk).  
  
The proper fix is to refactor our link dependencies on Windows platforms. That is however a risker and more involved change, so this PR intends to address the immediate issue rendering msquic unusable on GDK gaming platform.  

## Documentation

N/A
